### PR TITLE
Fix hanging DBus service when activating nonexistent tab (#9)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,8 @@ jobs:
         key: ${{ runner.os }}-ff2-${{ hashFiles('integration_tests/firefox_versions', 'integration_tests/firefox.py') }}
         restore-keys: |
           ${{ runner.os }}-ff2-
-    - run: ./run_tests.sh "$XPI_FILE" 2>>test.log
+    - name: Run integration tests
+      run: ./run_tests.sh -f origin "$XPI_FILE" 2>>test.log
       working-directory: integration_tests
       env:
         VIRTUALENV_DIR: ${{ env.XDG_CACHE_HOME }}/virtualenv

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -6,7 +6,8 @@ pub type WindowId = u32;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TabEvent {
     pub action: String,
-    pub key: Option<String>,
+    pub sequence_number: Option<u64>,
+    pub error: Option<String>,
 
     #[serde(flatten)]
     pub tab_info: TabInfo,

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,32 +1,43 @@
 function initialise() {
   var port = browser.runtime.connectNative("net.diegoveralli.tabreport");
 
-  port.onMessage.addListener(async (response) => {
-    let id = response['tab_id'];
-    let tab = await browser.tabs.get(id);
+  port.onMessage.addListener(async (request) => {
+    let error = null;
+
+    let preface = request['window_title_preface'];
+    let seqNum = request['sequence_number'];
 
     let syncKey = '';
-    
-    if (response['action'] == 'activate') {
-      await browser.tabs.update(id, { active: true });
-      // TODO: Setting focused and drawAttention should be optional, in case we want to 
-      // fully handle window and workspace switching on the window manager side
-      // TODO: In theory drawAttention does nothing on a window that's already focused,
-      // so it's probably useless here.
-      var attributes = { focused: true, drawAttention: true };
-
-      let preface = response['window_title_preface'];
-      if (preface) {
-        attributes['titlePreface'] = preface;
-        syncKey = preface;
-      }
-
-      await browser.windows.update(tab.windowId, attributes);
-    } else if (response['action'] == 'reset') {
-      await browser.windows.update(tab.windowId, {titlePreface: ""});
+    if (preface) {
+      syncKey = preface;
     }
 
-    // Send sync response to host, so that they know we're done with the update.
+    let id = request['tab_id'];
+
+    try {
+      let tab = await browser.tabs.get(id);
+
+      if (request['action'] == 'activate') {
+        await browser.tabs.update(id, { active: true });
+        // TODO: Setting focused and drawAttention should be optional, in case we want to 
+        // fully handle window and workspace switching on the window manager side
+        // TODO: In theory drawAttention does nothing on a window that's already focused,
+        // so it's probably useless here.
+        var attributes = { focused: true, drawAttention: true };
+
+        if (preface) {
+          attributes['titlePreface'] = preface;
+        }
+
+        await browser.windows.update(tab.windowId, attributes);
+      } else if (request['action'] == 'reset') {
+        await browser.windows.update(tab.windowId, {titlePreface: ""});
+      }
+    } catch (e) {
+      error = e;
+    }
+
+    // Send sync request to host, so that they know we're done with the update.
     // This is important when the client is hacking the window title to be able to locate
     // the window later: it will wait until we're done here, then go through the available
     // windows to find the one whose workspace it needs to switch to.
@@ -38,7 +49,13 @@ function initialise() {
     // host process to resume. There's a lot of xorg / i3 / sway / firefox code to go
     // through to understand what we can expect here because information on sequential
     // consistency is not part of the docs.
-    port.postMessage({'action': 'sync', 'key': syncKey, 'tab_id': id});
+
+    let message = {'action': 'sync', 'key': syncKey, 'tab_id': id, 'sequence_number': seqNum};
+    if (error != null) {
+      message['error'] = JSON.stringify(error);
+    }
+    
+    port.postMessage(message);
   });
 
   function sendUpdate(tabId, changes, force) {

--- a/integration_tests/firefox.py
+++ b/integration_tests/firefox.py
@@ -14,7 +14,7 @@ else:
 
 cache_dir = os.path.join(cache_home, "extension_testing")
 
-print(f'Download cache directory set to {cache_dir}')
+print(f"Download cache directory set to {cache_dir}")
 
 
 def get_marionette(ff_version: str, extension_path: str) -> Marionette:
@@ -30,8 +30,8 @@ def get_marionette(ff_version: str, extension_path: str) -> Marionette:
             subprocess.check_output(
                 ["tar", "xf", "firefox.tar.bz2"],
                 cwd=install_dir,
-                encoding='utf-8',
-                stderr=subprocess.STDOUT
+                encoding="utf-8",
+                stderr=subprocess.STDOUT,
             )
         )
 

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -3,3 +3,4 @@ requests==2.27.1
 types-requests==2.27.1
 mozprofile==2.5.0
 PyHamcrest==2.0.3
+packaging==21.3

--- a/integration_tests/test_server.py
+++ b/integration_tests/test_server.py
@@ -15,6 +15,7 @@ SERVER_ADDRESS = "127.0.1.1"
 def run_server(directory: str, address: str, port: int, stop_event: Event) -> None:
     handler_class = partial(SimpleHTTPRequestHandler, directory=directory)
     with ThreadingHTTPServer((address, port), handler_class) as httpd:
+
         def shutdown():
             stop_event.wait()
             httpd.shutdown()


### PR DESCRIPTION
Fix hanging DBus service when activating nonexistent tab (#9)

Also adds a test run against a previous DBus host version, to make
sure updating to the latest extension still work against an out of
date host.